### PR TITLE
Misc minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Successful component generation should result in output similar to the following
 
 ## Contributing
  
-Originally developed and contributed by Bounteous.
+Originally developed and contributed by [Bounteous](https://www.bounteous.com/insights/2019/07/31/aem-component-generator/).
 
 Contributions are welcomed! Read the [Contributing Guide](.github/CONTRIBUTING.md) for more information.
  

--- a/data-config.json
+++ b/data-config.json
@@ -164,7 +164,7 @@
             {
                 "field": "links",
                 "type": "multifield",
-                "model-name": "MultiLink",
+                "model-name": "DemoLink",
                 "use-existing-model": false,
                 "label": "Links",
                 "json-expose": true,

--- a/src/main/java/com/adobe/aem/compgenerator/javacodemodel/ImplementationBuilder.java
+++ b/src/main/java/com/adobe/aem/compgenerator/javacodemodel/ImplementationBuilder.java
@@ -21,11 +21,11 @@ package com.adobe.aem.compgenerator.javacodemodel;
 
 import com.adobe.acs.commons.models.injectors.annotation.ChildResourceFromRequest;
 import com.adobe.acs.commons.models.injectors.annotation.SharedValueMapValue;
-import com.adobe.cq.export.json.ComponentExporter;
-import com.adobe.cq.export.json.ExporterConstants;
 import com.adobe.aem.compgenerator.Constants;
 import com.adobe.aem.compgenerator.models.GenerationConfig;
 import com.adobe.aem.compgenerator.models.Property;
+import com.adobe.cq.export.json.ComponentExporter;
+import com.adobe.cq.export.json.ExporterConstants;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sun.codemodel.JAnnotationArrayMember;
@@ -49,6 +49,7 @@ import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -250,7 +251,12 @@ public class ImplementationBuilder extends JavaCodeBuilder {
             }
         }
 
-        getMethod.body()._return(jFieldVar);
+
+        if (jFieldVar.type().erasure().fullName().equals(List.class.getName())) {
+            getMethod.body()._return(codeModel.ref(Collections.class).staticInvoke("unmodifiableList").arg(jFieldVar));
+        } else {
+            getMethod.body()._return(jFieldVar);
+        }
     }
 
     /**

--- a/src/main/java/com/adobe/aem/compgenerator/javacodemodel/InterfaceBuilder.java
+++ b/src/main/java/com/adobe/aem/compgenerator/javacodemodel/InterfaceBuilder.java
@@ -35,6 +35,7 @@ import com.sun.codemodel.JPackage;
 import com.sun.codemodel.JType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.CaseUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -181,13 +182,16 @@ public class InterfaceBuilder extends JavaCodeBuilder {
      * @param property
      */
     private void addJavadocToMethod(JMethod method, Property property) {
-        JDocComment javadoc = method.javadoc();
+        String javadocStr = null;
         if (StringUtils.isNotBlank(property.getJavadoc())) {
-            javadoc.append(property.getJavadoc());
-            javadoc.append("\n\n@return " + getGetterMethodReturnType(property).name());
+            javadocStr = property.getJavadoc();
         } else if (generationConfig.getOptions() != null && generationConfig.getOptions().isHasGenericJavadoc()) {
-            javadoc.append("Get the " + property.getField() + ".");
-            javadoc.append("\n\n@return " + getGetterMethodReturnType(property).name());
+            javadocStr = "Get the " + property.getField() + ".";
+        }
+        if (StringUtils.isNotBlank(javadocStr)) {
+            JDocComment javadoc = method.javadoc();
+            javadoc.append(javadocStr).append("");
+            javadoc.append("\n\n@return " + StringEscapeUtils.escapeHtml4(getGetterMethodReturnType(property).name()));
         }
     }
 }

--- a/src/main/java/com/adobe/aem/compgenerator/javacodemodel/JavaCodeModel.java
+++ b/src/main/java/com/adobe/aem/compgenerator/javacodemodel/JavaCodeModel.java
@@ -91,7 +91,7 @@ public class JavaCodeModel {
      * Builds your slingModel interface with all required annotation,
      * fields and getters based on the <code>generationConfig</code>.
      */
-    private void buildInterface() throws JClassAlreadyExistsException {
+    private void buildInterface() {
         InterfaceBuilder builder = new InterfaceBuilder(codeModel, generationConfig, generationConfig.getJavaFormatedName());
         jc = builder.build();
     }


### PR DESCRIPTION
- Updated getters for `List` to return an unmodifiable list to avoid triggering Adobe Cloud Manager code quality warnings
- Updated javadoc add an empty block when default javadoc is turned off and individual field javadoc is not specified
- Renamed `MultiLink` to `DemoLink` in the demo config file, since `MultiLink` was a misnomer for a model storing a single link
- Updated parameterized List returns (e.g. List<String>) to escape the < and > in javadoc to avoid issues breaking HTML docs