### PR TITLE
resolves #48 add support for multifield-nested images

### DIFF
--- a/data-config.json
+++ b/data-config.json
@@ -255,6 +255,12 @@
                         "label": "Label",
                         "description": "Label to display on the link",
                         "json-expose": true
+                    },
+                    {
+                        "field": "linkIcon",
+                        "type": "image",
+                        "label": "Link Icon",
+                        "json-expose": true
                     }
                 ]
             }

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,48 @@
                     </descriptorRefs>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>smoketest-generation-example-basedir</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}/smoketest"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>smoketest-generation-example</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-jar</argument>
+                                <argument>../component-generator-${project.version}.jar</argument>
+                                <argument>../../data-config.json</argument>
+                            </arguments>
+                            <workingDirectory>${project.build.directory}/smoketest</workingDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>adobe</groupId>
     <artifactId>component-generator</artifactId>
-    <version>1.0</version>
+    <version>1.1-SNAPSHOT</version>
     <build>
         <plugins>
             <plugin>
@@ -37,7 +37,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <finalName>component-generator-1.0</finalName>
+                    <finalName>component-generator-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                     <archive>
                         <manifest>

--- a/src/main/java/com/adobe/aem/compgenerator/Constants.java
+++ b/src/main/java/com/adobe/aem/compgenerator/Constants.java
@@ -36,7 +36,6 @@ public class Constants {
     public static final String RESOURCE_TYPE_NUMBER = "granite/ui/components/coral/foundation/form/numberfield";
     public static final String RESOURCE_TYPE_PAGEFIELD = "cq/gui/components/coral/common/form/pagefield";
     public static final String RESOURCE_TYPE_PATHFIELD = "granite/ui/components/coral/foundation/form/pathfield";
-    public static final String RESOURCE_TYPE_RADIO = "granite/ui/components/coral/foundation/form/radio";
     public static final String RESOURCE_TYPE_RADIOGROUP = "granite/ui/components/coral/foundation/form/radiogroup";
     public static final String RESOURCE_TYPE_SECTION = "granite/ui/components/foundation/section";
     public static final String RESOURCE_TYPE_SELECT = "granite/ui/components/coral/foundation/form/select";

--- a/src/main/java/com/adobe/aem/compgenerator/javacodemodel/JavaCodeModel.java
+++ b/src/main/java/com/adobe/aem/compgenerator/javacodemodel/JavaCodeModel.java
@@ -130,7 +130,11 @@ public class JavaCodeModel {
      */
     private void generateCodeFiles() throws IOException {
         // RenameFileCodeWritern to rename existing files
-        CodeWriter codeWriter = new RenameFileCodeWriter(new File(generationConfig.getProjectSettings().getBundlePath()));
+        File bundlePath = new File(generationConfig.getProjectSettings().getBundlePath());
+        if (!bundlePath.exists()) {
+            bundlePath.mkdirs();
+        }
+        CodeWriter codeWriter = new RenameFileCodeWriter(bundlePath);
 
         // PrologCodeWriter to prepend the copyright template in each file
         String templateString = CommonUtils.getTemplateFileAsString(Constants.TEMPLATE_COPYRIGHT_JAVA, generationConfig);
@@ -138,7 +142,11 @@ public class JavaCodeModel {
 
         codeModel.build(prologCodeWriter);
         if (generationConfig.getOptions().isHasTestClass()) {
-            CodeWriter codeWriterTest = new RenameFileCodeWriter(new File(generationConfig.getProjectSettings().getTestPath()));
+            File testPath = new File(generationConfig.getProjectSettings().getTestPath());
+            if (!testPath.exists()) {
+                testPath.mkdirs();
+            }
+            CodeWriter codeWriterTest = new RenameFileCodeWriter(testPath);
             PrologCodeWriter prologCodeWriterTest = new PrologCodeWriter(codeWriterTest, templateString);
             codeModelTest.build(prologCodeWriterTest);
         }

--- a/src/main/java/com/adobe/aem/compgenerator/utils/DialogUtils.java
+++ b/src/main/java/com/adobe/aem/compgenerator/utils/DialogUtils.java
@@ -159,7 +159,9 @@ public class DialogUtils {
         Element propertyNode = document.createElement(property.getField());
 
         propertyNode.setAttribute(Constants.JCR_PRIMARY_TYPE, Constants.NT_UNSTRUCTURED);
-        propertyNode.setAttribute(Constants.PROPERTY_SLING_RESOURCETYPE, getSlingResourceType(property.getType()));
+        Optional.ofNullable(getSlingResourceType(property.getType())).ifPresent(resType -> {
+            propertyNode.setAttribute(Constants.PROPERTY_SLING_RESOURCETYPE, resType);
+        });
 
         // Some of the properties are optional based on the different types available.
         addBasicProperties(propertyNode, property);
@@ -213,7 +215,9 @@ public class DialogUtils {
                     actualField.setAttribute(Constants.PROPERTY_CQ_MSM_LOCKABLE, "./" + property.getField());
 
                     Property prop = property.getItems().get(0);
-                    actualField.setAttribute(Constants.PROPERTY_SLING_RESOURCETYPE, getSlingResourceType(prop.getType()));
+                    Optional.ofNullable(getSlingResourceType(prop.getType())).ifPresent(resType -> {
+                        actualField.setAttribute(Constants.PROPERTY_SLING_RESOURCETYPE, resType);
+                    });
                     addBasicProperties(actualField, prop);
                     processAttributes(actualField, prop);
                     items.appendChild(actualField);
@@ -493,8 +497,6 @@ public class DialogUtils {
                 return Constants.RESOURCE_TYPE_SELECT;
             } else if (StringUtils.equalsIgnoreCase("radiogroup", type)) {
                 return Constants.RESOURCE_TYPE_RADIOGROUP;
-            } else if (StringUtils.equalsIgnoreCase("radio", type)) {
-                return Constants.RESOURCE_TYPE_RADIO;
             } else if (StringUtils.equalsIgnoreCase("image", type)) {
                 return Constants.RESOURCE_TYPE_IMAGE;
             } else if (StringUtils.equalsIgnoreCase("multifield", type)) {

--- a/src/main/java/com/adobe/aem/compgenerator/utils/HTMLUtils.java
+++ b/src/main/java/com/adobe/aem/compgenerator/utils/HTMLUtils.java
@@ -87,10 +87,17 @@ public class HTMLUtils {
             StringBuilder items = new StringBuilder(initialListHtml);
             int index = 1;
             for (Property property : prop.getItems()) {
-                items.append(property.getLabel())
-                        .append(": ${item.")
-                        .append(property.getField())
-                        .append(prop.getItems().size() == index ? "}" : "} | ");
+                if ("image".equalsIgnoreCase(property.getType())) {
+                    items.append(property.getLabel())
+                            .append(": ${item.")
+                            .append(property.getField()).append(".src")
+                            .append(prop.getItems().size() == index ? "}" : "} | ");
+                } else {
+                    items.append(property.getLabel())
+                            .append(": ${item.")
+                            .append(property.getField())
+                            .append(prop.getItems().size() == index ? "}" : "} | ");
+                }
                 index++;
             }
             return items + "</p>\n    </div>\n";


### PR DESCRIPTION

## Description

* Added droptarget attributes and image restype to image fields nested in multifields
* Changed current version in pom to 1.1-SNAPSHOT
* Added executions to integration test phases to actually run the jar against the sample data-config.json file during the build
* Fixed bugs arising from this added smoketest execution

## Related Issue

see #48 

## Motivation and Context

Multifield images should have full support, because developers expect it.

## How Has This Been Tested?

tested generation against expected markup
tested generated model binding in htl
tested drag-drop functionality in author

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
